### PR TITLE
support delayed_job_mongoid as well

### DIFF
--- a/lib/workless/railtie.rb
+++ b/lib/workless/railtie.rb
@@ -5,6 +5,7 @@ module Delayed
     initializer :after_initialize do
       Delayed::Worker.max_attempts = 3
       Delayed::Backend::ActiveRecord::Job.send(:include, Delayed::Workless::Scaler) if defined?(Delayed::Backend::ActiveRecord::Job)
+      Delayed::Backend::Mongoid::Job.send(:include, Delayed::Workless::Scaler) if defined?(Delayed::Backend::Mongoid::Job)      
     end
   end
 end


### PR DESCRIPTION
just added one line to include Scaler into Delayed::Backend::Mongoid::Job if it is defined.
