### PR TITLE
Fixed issue #4, delayed jobs creating multiple processes

### DIFF
--- a/lib/workless/scalers/local.rb
+++ b/lib/workless/scalers/local.rb
@@ -7,7 +7,7 @@ module Delayed
       class Local < Base
 
         def up
-          Rush::Box.new[Rails.root].bash("rake jobs:work", :background => true)
+          Rush::Box.new[Rails.root].bash("rake jobs:work", :background => true) if workers == 0
           true
         end
 


### PR DESCRIPTION
Turns out the issue for creating multiple processes was just a missing check for the current worker count. This commit fixes the issue #4 file by @holden
