### PR TITLE
changes to workless

### DIFF
--- a/lib/workless/scalers/local.rb
+++ b/lib/workless/scalers/local.rb
@@ -12,7 +12,12 @@ module Delayed
         end
 
         def down
-          Rush::Box.new.processes.filter(:cmdline => /rake jobs:work/).kill unless workers == 0 or jobs.count > 0
+          #Rush::Box.new.processes.filter(:cmdline => /rake jobs:work/).kill unless workers == 0 or jobs.count > 0
+          #instead of just killing the process which exited the thing way too fast and didn't remove the entry from the database table
+          #now we will just set exit to true so that it will exit the loop in the run method in delayed_job
+          #and I used jobs.count - 1 because when the after_destroy hook is trigged the job is not yet actually destroyed.
+          #this works much better for my local development system, OS X Lion. 
+          $exit = true unless workers == 0 or jobs.count - 1 > 0
           true
         end
 


### PR DESCRIPTION
lostboy,

I've spent a couple of days trying to get your gem to work on my local development environment, OS X Lion. I was having issues with the process ending too quickly and therefore leaving a locked entry in the delayed_job database table. It was working fine on heroku but was not working on my local development machine. I've gone ahead and made a few changes so that it works correctly on both heroku and my local development machine now. These changes are based on how Pedro does autoscaling here: https://github.com/pedro/delayed_job/blob/autoscaling/lib/delayed/manager/local.rb and Phaza autoscaling gem here: https://github.com/phaza/Heroku-Delayed-Job-Autoscale/blob/master/lib/heroku_delayed_job_autoscale.rb.

-Jason
