### PR TITLE
autoloading scalers

### DIFF
--- a/lib/workless/scaler.rb
+++ b/lib/workless/scaler.rb
@@ -1,11 +1,11 @@
-require 'workless/scalers/heroku'
-require 'workless/scalers/heroku_cedar'
-require 'workless/scalers/local'
-require 'workless/scalers/null'
-
 module Delayed
   module Workless
     module Scaler
+
+      autoload :Heroku,      "workless/scalers/heroku"
+      autoload :HerokuCedar, "workless/scalers/heroku_cedar"
+      autoload :Local,       "workless/scalers/local"
+      autoload :Null,        "workless/scalers/null"
 
       def self.included(base)
         base.send :extend, ClassMethods


### PR DESCRIPTION
Hey,

Another pull request.

We've noticed that rush gem heavily pollutes our environment, hence we do not want to load it every time. To solve this I've switched dependency loading to autoload.

Hope you'll find it useful, thanks!
