### PR TITLE
Scale the workers after_commit

### DIFF
--- a/lib/workless/scaler.rb
+++ b/lib/workless/scaler.rb
@@ -10,9 +10,9 @@ module Delayed
       def self.included(base)
         base.send :extend, ClassMethods
         base.class_eval do
-          after_destroy "self.class.scaler.down"
-          after_create "self.class.scaler.up"
-          after_update "self.class.scaler.down", :unless => Proc.new {|r| r.failed_at.nil? }
+          after_commit "self.class.scaler.down", :on => :destroy
+          after_commit "self.class.scaler.up", :on => :create
+          after_commit "self.class.scaler.down", :on => :update, :unless => Proc.new {|r| r.failed_at.nil? }
         end
 
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,13 +8,7 @@ require 'workless'
 module Delayed
   module Job
     class Delayed::Job::Mock
-      def self.after_destroy(method, *args)
-      end
-
-      def self.after_create(method, *args)
-      end
-
-      def self.after_update(method, *args)
+      def self.after_commit(method, *args, &block)
       end
     end
   end


### PR DESCRIPTION
This will scale the workers after committing the changes
to the database. This will fix issue #34.

Main point of this is to relax the scaling to happen when
the jobs are in the database. This may also have an effect 
on issue #33.
