### PR TITLE
Fix for Mongoid 3

### DIFF
--- a/lib/workless/scalers/base.rb
+++ b/lib/workless/scalers/base.rb
@@ -3,19 +3,21 @@ require 'delayed_job'
 module Delayed
   module Workless
     module Scaler
-  
+
       class Base
         def self.jobs
-          Delayed::Job.all(:conditions => { :failed_at => nil })
+          if defined?(Mongoid) && Mongoid::VERSION.to_i >= 3
+            Delayed::Job.where(:failed_at => nil)
+          else
+            Delayed::Job.all(:conditions => { :failed_at => nil })
+          end
         end
       end
 
       module HerokuClient
-
         def client
           @client ||= ::Heroku::API.new(:api_key => ENV['HEROKU_API_KEY'])
         end
-
       end
 
     end


### PR DESCRIPTION
Starting with version 3, Mongoid changed the [querying](http://mongoid.org/en/mongoid/docs/querying.html) so `Delayed::Job.all(:conditions => { :failed_at => nil })` returns empty results and therefore no scaling up is happening. This fixes that.
