### PR TITLE
Add "How does Workless work?" to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ heroku config:add WORKLESS_WORKERS_RATIO=50
 
 In this example, it will scale up to a maximum of 10 workers, firing up 1 worker for every 50 jobs on the queue. The minimum will be 0 workers, but you could set it to a higher value if you want.
 
+## How does Workless work?
+
+- `Delayed::Workless::Scaler` is mixed into the `Delayed::Job` class, which adds a bunch of callbacks to it.
+- When a job is created on the database, a `create` callback starts a worker.
+- The worker runs the job, which removes it from the database.
+- A `destroy` callback stops the worker.
+
 ## Note on Patches/Pull Requests
  
 * Please fork the project.


### PR DESCRIPTION
Hi,

We just discovered workless, and it is pretty awesome.
Saves us quite a lot of money that we would've spent on idling Heroku workers.

The thing is, I had to clone it and read the source just to figure out how the workers were started.
It seemed like too much _magic_ to allow without understanding how it worked behind the scenes.

I added a few lines to the README explaining this.
## 

Timothy Andrew
[nilenso.com](http://nilenso.com)
