### PR TITLE
A few small tweaks that should reduce the number of Heroku API calls and help apps not hit the Heroku API rate limit.

### DIFF
--- a/lib/workless/scalers/heroku.rb
+++ b/lib/workless/scalers/heroku.rb
@@ -13,7 +13,7 @@ module Delayed
         end
 
         def self.down
-          client.put_workers(ENV['APP_NAME'], 0) unless self.workers == 0 or self.jobs.count > 0
+          client.put_workers(ENV['APP_NAME'], 0) unless self.jobs.count > 0 or self.workers == 0
         end
 
         def self.workers

--- a/lib/workless/scalers/heroku_cedar.rb
+++ b/lib/workless/scalers/heroku_cedar.rb
@@ -7,11 +7,11 @@ module Delayed
         extend Delayed::Workless::Scaler::HerokuClient
 
         def self.up
-          client.post_ps_scale(ENV['APP_NAME'], 'worker', self.workers_needed) if self.workers < self.workers_needed
+          client.post_ps_scale(ENV['APP_NAME'], 'worker', self.workers_needed) if self.workers_needed > self.min_workers and self.workers < self.workers_needed
         end
 
         def self.down
-          client.post_ps_scale(ENV['APP_NAME'], 'worker', self.min_workers) unless self.workers == self.min_workers or self.jobs.count > 0
+          client.post_ps_scale(ENV['APP_NAME'], 'worker', self.min_workers) unless self.jobs.count > 0 or self.workers == self.min_workers
         end
 
         def self.workers

--- a/spec/workless/mongoid_scaling_spec.rb
+++ b/spec/workless/mongoid_scaling_spec.rb
@@ -30,7 +30,7 @@ describe Delayed::Mongoid::Job do
     end
     context 'with 1 worker' do
       before(:each) do
-        Delayed::Mongoid::Job::Mock.scaler.should_receive(:workers).and_return(1)
+        Delayed::Mongoid::Job::Mock.scaler.stub(:workers).and_return(1)
       end
       it "should scale down to none" do
         if_there_are_jobs 1
@@ -48,7 +48,7 @@ describe Delayed::Mongoid::Job do
 
     context 'with 5 workers' do
       before(:each) do
-        Delayed::Mongoid::Job::Mock.scaler.should_receive(:workers).and_return(5)
+        Delayed::Mongoid::Job::Mock.scaler.stub(:workers).and_return(5)
       end
       it "should scale down to none" do
         if_there_are_jobs 0

--- a/spec/workless/scalers/heroku_cedar_multiple_workers_spec.rb
+++ b/spec/workless/scalers/heroku_cedar_multiple_workers_spec.rb
@@ -3,9 +3,13 @@ require 'spec_helper'
 describe Delayed::Workless::Scaler::HerokuCedar do
 
   describe 'up' do
+    after(:each) do
+      Delayed::Workless::Scaler::HerokuCedar.up
+    end
+
     context 'with no workers' do
       before(:each) do
-        Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).and_return(0)
+        Delayed::Workless::Scaler::HerokuCedar.stub(:workers).and_return(0)
       end
 
       context 'with 10 max workers' do
@@ -21,43 +25,31 @@ describe Delayed::Workless::Scaler::HerokuCedar do
           it 'should set workers to 1 for 24 jobs' do
             if_there_are_jobs       24
             should_scale_workers_to 1
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 1 for 25 jobs' do
             if_there_are_jobs       25
             should_scale_workers_to 1
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 2 for 26 jobs' do
             if_there_are_jobs       26
             should_scale_workers_to 2
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 3 for 51 jobs' do
             if_there_are_jobs       51
             should_scale_workers_to 3
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 10 for 250 jobs' do
             if_there_are_jobs       250
             should_scale_workers_to 10
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 10 for 5000 jobs' do
             if_there_are_jobs       5000
             should_scale_workers_to 10
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
         end
 
@@ -69,29 +61,21 @@ describe Delayed::Workless::Scaler::HerokuCedar do
           it 'should set workers to 1 for 50 jobs' do
             if_there_are_jobs       50
             should_scale_workers_to 1
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 2 for 51 jobs' do
             if_there_are_jobs       51
             should_scale_workers_to 2
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 10 for 500 jobs' do
             if_there_are_jobs       500
             should_scale_workers_to 10
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set workers to 10 for 501 jobs' do
             if_there_are_jobs       501
             should_scale_workers_to 10
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
         end
       end
@@ -99,12 +83,34 @@ describe Delayed::Workless::Scaler::HerokuCedar do
 
     context 'with workers' do
       before(:each) do
-        Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).and_return(1)
+        Delayed::Workless::Scaler::HerokuCedar.stub(:workers).and_return(1)
       end
 
       context 'with 10 max workers' do
         before(:each) do
           ENV['WORKLESS_MAX_WORKERS'] = '10'
+        end
+
+        context 'with 1 min workers' do
+          before(:each) do
+            ENV['WORKLESS_MIN_WORKERS'] = '2'
+          end
+
+          after(:all) do
+            #Clear up for other specs
+            ENV.delete('WORKLESS_MIN_WORKERS')
+          end
+
+          it "should not fetch the number of workers for 1 jobs" do
+            if_there_are_jobs 1
+            Delayed::Workless::Scaler::HerokuCedar.should_not_receive(:workers)
+          end
+
+          it "should fetch the number of wokers exactly once for 1000 jobs" do
+            if_there_are_jobs 1000
+            Delayed::Workless::Scaler::HerokuCedar.client.stub(:post_ps_scale).and_return(true)
+            Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).exactly(:once)
+          end
         end
 
         context 'with a ratio of 25 jobs per worker' do
@@ -115,15 +121,11 @@ describe Delayed::Workless::Scaler::HerokuCedar do
           it 'should not set more workers for 25 jobs' do
             if_there_are_jobs       25
             should_not_scale_workers
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
 
           it 'should set more workers for 26 jobs' do
             if_there_are_jobs       26
             should_scale_workers_to 2
-
-            Delayed::Workless::Scaler::HerokuCedar.up
           end
         end
       end
@@ -131,8 +133,12 @@ describe Delayed::Workless::Scaler::HerokuCedar do
   end
 
   describe 'down' do
+    after(:each) do
+      Delayed::Workless::Scaler::HerokuCedar.down
+    end
+
     before(:each) do
-      Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).and_return(1)
+      Delayed::Workless::Scaler::HerokuCedar.stub(:workers).and_return(1)
       ENV['WORKLESS_MAX_WORKERS']   = '10'
       ENV['WORKLESS_WORKERS_RATIO'] = '5'
     end
@@ -145,15 +151,22 @@ describe Delayed::Workless::Scaler::HerokuCedar do
       it 'should not scale down if there is a pending job' do
         if_there_are_jobs 1
         should_not_scale_workers
+      end
 
-        Delayed::Workless::Scaler::HerokuCedar.down
+      it "should not fetch the number of workers if there is a pending job" do
+        if_there_are_jobs 1
+        Delayed::Workless::Scaler::HerokuCedar.should_not_receive(:workers)
       end
 
       it 'should scale to 0 if there are no pending jobs' do
         if_there_are_jobs       0
         should_scale_workers_to 0
+      end
 
-        Delayed::Workless::Scaler::HerokuCedar.down
+      it "should fetch the number of workers if there are no pending jobs" do
+        if_there_are_jobs 0
+        should_scale_workers_to 0
+        Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).exactly(:once)
       end
     end
 
@@ -165,15 +178,21 @@ describe Delayed::Workless::Scaler::HerokuCedar do
       it 'should not scale down if there is a pending job' do
         if_there_are_jobs 1
         should_not_scale_workers
+      end
 
-        Delayed::Workless::Scaler::HerokuCedar.down
+      it "should not fetch the number of workers if there is a pending job" do
+        if_there_are_jobs 1
+        Delayed::Workless::Scaler::HerokuCedar.should_not_receive(:workers)
       end
 
       it 'should not scale down even if there are no pending jobs' do
         if_there_are_jobs 0
         should_not_scale_workers
+      end
 
-        Delayed::Workless::Scaler::HerokuCedar.down
+      it "should fetch the number of workers if there are no pending jobs" do
+        if_there_are_jobs 0
+        Delayed::Workless::Scaler::HerokuCedar.should_receive(:workers).exactly(:once)
       end
     end
   end


### PR DESCRIPTION
I've changed the logic for when to scale up or down slightly to avoid fetching the worker numbers from Heroku API when it's not necessary. 

The current behaviour has not been changed at all. The only consequence is less API calls which helps with Heroku API rate limits and should also slightly improve performance.

This should help with Issue #33.
