### PR TITLE
Checking jobs differently if using Mongoid

### DIFF
--- a/lib/workless/scalers/base.rb
+++ b/lib/workless/scalers/base.rb
@@ -9,7 +9,11 @@ module Delayed
           if Rails.version >= "3.0.0"
             Delayed::Job.where(:failed_at => nil)
           else
-            Delayed::Job.all(:conditions => { :failed_at => nil })
+            if ENV['MONGOHQ_URL'].present?
+              Delayed::Job.all
+            else
+              Delayed::Job.all(:conditions => { :failed_at => nil })
+            end
           end
         end
       end


### PR DESCRIPTION
In response to this error - https://github.com/lostboy/workless/issues/47 - I've messed a bit around with the base class.

I didn't know how to check, if we are using mongoid, so now I'm just checking if the user is using MongoHQ, which will give him the MONGO_HQ environment variable.
