### PR TITLE
Fix rails deprecation warnings (use after_commit -> { })

### DIFF
--- a/lib/workless/scaler.rb
+++ b/lib/workless/scaler.rb
@@ -11,9 +11,9 @@ module Delayed
         base.send :extend, ClassMethods
         if base.to_s =~ /ActiveRecord/
           base.class_eval do
-            after_commit "self.class.scaler.down", :on => :update, :if => Proc.new {|r| !r.failed_at.nil? }
-            after_commit "self.class.scaler.down", :on => :destroy, :if => Proc.new {|r| r.destroyed? or !r.failed_at.nil? }
-            after_commit "self.class.scaler.up", :on => :create
+            after_commit -> { self.class.scaler.down }, :on => :update, :if => Proc.new {|r| !r.failed_at.nil? }
+            after_commit -> { self.class.scaler.down }, :on => :destroy, :if => Proc.new {|r| r.destroyed? or !r.failed_at.nil? }
+            after_commit -> { self.class.scaler.up }, :on => :create
           end          
         elsif base.to_s =~ /Sequel/
           base.send(:define_method, 'after_destroy') do

--- a/workless.gemspec
+++ b/workless.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<rush>)
   s.add_runtime_dependency(%q<delayed_job>, [">= 2.0.7"])
 
-  s.add_development_dependency(%q<rspec>)
+  s.add_development_dependency(%q<rspec>, ["~> 2.0"])
 end
 


### PR DESCRIPTION
Hello

That's part of the `rails 5` deprecation warnings cleanup.
It fixes `DEPRECATION WARNING: Passing string to define callback`.
Change is almost mechanical and I hope new lambda syntax is quite old already (`ruby 1.9`).

I've also noticed specs failure with `rspec 3`, changed gemspec to use `rspec 2` instead.