### PR TITLE
Added ability set the size of dynos when scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ heroku config:add WORKLESS_WORKERS_RATIO=50
 
 In this example, it will scale up to a maximum of 10 workers, firing up 1 worker for every 50 jobs on the queue. The minimum will be 0 workers, but you could set it to a higher value if you want.
 
+## Worker size
+
+By default heroku will scale using standard-1x dynos, if you wish to use a different pro dyno size use the following config variable:
+
+<pre>
+heroku config:add WORKLESS_WORKER_SIZE=performance-m
+</pre>
+
+Possible values for [dyno size](https://devcenter.heroku.com/articles/dyno-types)
+
+Note: This will not work for Hobby dynos, switch to Professional to support configuring dyno size
+
 ## How does Workless work?
 
 - `Delayed::Workless::Scaler` is mixed into the `Delayed::Job` class, which adds a bunch of callbacks to it.

--- a/lib/workless/scalers/heroku.rb
+++ b/lib/workless/scalers/heroku.rb
@@ -11,6 +11,7 @@ module Delayed
         def self.up
           return unless workers_needed > min_workers && workers < workers_needed
           updates = { "quantity": workers_needed }
+          updates[:size] = worker_size if worker_size
           client.formation.update(ENV['APP_NAME'], 'worker', updates)
         end
 
@@ -29,6 +30,7 @@ module Delayed
         # ENV['WORKLESS_WORKERS_RATIO']
         # ENV['WORKLESS_MAX_WORKERS']
         # ENV['WORKLESS_MIN_WORKERS']
+        # ENV['WORKLESS_WORKER_SIZE']
         #
         def self.workers_needed
           [[(jobs.count.to_f / workers_ratio).ceil, max_workers].min, min_workers].max
@@ -48,6 +50,10 @@ module Delayed
 
         def self.min_workers
           ENV['WORKLESS_MIN_WORKERS'].present? ? ENV['WORKLESS_MIN_WORKERS'].to_i : 0
+        end
+
+        def self.worker_size
+          ENV['WORKLESS_WORKER_SIZE'].present? ? ENV['WORKLESS_WORKER_SIZE'] : nil
         end
       end
     end

--- a/spec/workless/scalers/heroku_spec.rb
+++ b/spec/workless/scalers/heroku_spec.rb
@@ -22,6 +22,18 @@ describe Delayed::Workless::Scaler::Heroku do
         Delayed::Workless::Scaler::Heroku.client.formation.should_receive(:update).once.with(ENV['APP_NAME'], 'worker', updates)
         Delayed::Workless::Scaler::Heroku.up
       end
+
+      context 'with WORKLESS_WORKER_SIZE' do
+        before do
+          ENV['WORKLESS_WORKER_SIZE'] = 'performance-l'
+        end
+
+        it 'should set the workers size to WORKLESS_WORKER_SIZE' do
+          updates = { "quantity": 1, "size": "performance-l" }
+          Delayed::Workless::Scaler::Heroku.client.formation.should_receive(:update).once.with(ENV['APP_NAME'], 'worker', updates)
+          Delayed::Workless::Scaler::Heroku.up
+        end
+      end
     end
 
     context 'with workers' do


### PR DESCRIPTION
Workless currently only scales workers using the heroku default standard-1x dyno
Certain jobs really benefit from high performance dynos such as processing images and videos.

This PR adds the ability to configure the size of dyno used when scaling.

TODO (Later): Add the ability to configure this per job